### PR TITLE
fix(resume): open the résumé PDF in a new tab (native viewer)

### DIFF
--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -51,10 +51,12 @@ export default function ResumePage() {
           <p className="eyebrow">Resume</p>
           <a
             href="/data/Resume_DevinHunt_Jun2026.pdf"
-            download="Devin-Hunt-Resume-June2026.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="View résumé PDF (opens in a new tab)"
             className="link-quiet print:hidden"
           >
-            Download PDF
+            View PDF
           </a>
         </header>
 


### PR DESCRIPTION
## What
The resume page's PDF link forced a file download (`download` attribute). This changes it to **open the PDF in a new tab using the browser's native PDF viewer**.

## How
- Remove `download`; add `target="_blank"` + `rel="noopener noreferrer"`. The PDF is same-origin and served as `application/pdf`, so the browser renders it inline in the new tab.
- Relabel **"Download PDF" to "View PDF"** to match the new behavior, with an `aria-label` noting it opens in a new tab.

## Scope
One-line behavior change in `app/resume/page.tsx`. No other pages affected.

## Verification
- `npm run build` clean (8/8 static pages).
- Built `out/resume.html` confirmed: `target="_blank"`, no `download` attr, label "View PDF".
- PDF served with `Content-Type: application/pdf` (renders inline).